### PR TITLE
Fix coefficient comment typos

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ def read_bmp280():
 	# Read data back from 0x88(136), 24 bytes
 	b1 = bus.read_i2c_block_data(0x76, 0x88, 24)
 	# Convert the data
-	# Temp coefficents
+        # Temp coefficients
 	dig_T1 = b1[1] * 256 + b1[0]
 	dig_T2 = b1[3] * 256 + b1[2]
 	if dig_T2 > 32767 :
@@ -68,7 +68,7 @@ def read_bmp280():
 	dig_T3 = b1[5] * 256 + b1[4]
 	if dig_T3 > 32767 :
         	dig_T3 -= 65536
-	# Pressure coefficents
+        # Pressure coefficients
 	dig_P1 = b1[7] * 256 + b1[6]
 	dig_P2 = b1[9] * 256 + b1[8]
 	if dig_P2 > 32767 :


### PR DESCRIPTION
## Summary
- correct spelling of temperature and pressure coefficient comments in BMP280 reader

## Testing
- `python -m py_compile main.py` *(fails: TabError: inconsistent use of tabs and spaces in indentation)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5c50179483219244d36c2c61a4f7