### PR TITLE
Clarify BMP280 data read comment

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,9 +106,10 @@ def read_bmp280():
 	time.sleep(0.5)
 	# BMP280 address, 0x76(118)
 	# Read data back from 0xF7(247), 8 bytes
-	# Pressure MSB, Pressure LSB, Pressure xLSB, Temperature MSB, Temperature LSB
-	# Temperature xLSB, Humidity MSB, Humidity LSB
+	# Pressure MSB, Pressure LSB, Pressure xLSB, Temperature MSB, Temperature LSB,
+	# Temperature xLSB and two unused bytes (BMP280 has no humidity sensor)
 	data = bus.read_i2c_block_data(0x76, 0xF7, 8)
+	# The BMP280 does not supply humidity data
 	# Convert pressure and temperature data to 19-bits
 	adc_p = ((data[0] * 65536) + (data[1] * 256) + (data[2] & 0xF0)) / 16
 	adc_t = ((data[3] * 65536) + (data[4] * 256) + (data[5] & 0xF0)) / 16


### PR DESCRIPTION
## Summary
- clarify that the BMP280 read returns pressure and temperature bytes only
- note that BMP280 lacks a humidity sensor

## Testing
- `python -m py_compile main.py` *(fails: TabError: inconsistent use of tabs and spaces in indentation (main.py, line 253))*

------
https://chatgpt.com/codex/tasks/task_e_689a5c90d21c83218aa438d6081bd5df